### PR TITLE
make XSLT generate compact plainExample includes

### DIFF
--- a/tools/extractGuidelines.xsl
+++ b/tools/extractGuidelines.xsl
@@ -1217,7 +1217,7 @@ version: "<xsl:value-of select="$plain.version"/>"
                 <xsl:otherwise><xsl:value-of select="$pos"/></xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        <xsl:variable name="path" select="'examples/' || $chapter || '/' || $chapter || '-sample' || $posLink || '.xml'"/>{% include plainExample.html example="<xsl:value-of select="$path"/>" valid="<xsl:value-of select="@valid"/>" version=page.version %}
+        <xsl:variable name="path" select="$chapter || '/' || $chapter || '-sample' || $posLink || '.xml'"/>{% include mei example="<xsl:value-of select="$path"/>" valid="<xsl:value-of select="@valid"/>" %}
     </xsl:template>
         
     <xsl:template match="tei:table">


### PR DESCRIPTION
Before this commit the generated includes for plainExaples was rather long, creating a lot of noise when editing the .md files. After this commit the generated includes will be more compact creating less noise. Closes #4