### PR TITLE
add template for text-nodes in mode plain

### DIFF
--- a/tools/extractGuidelines.xsl
+++ b/tools/extractGuidelines.xsl
@@ -144,6 +144,17 @@
         </xsl:for-each>
     </xsl:variable>
     
+    <xsl:template match="text()" mode="plain" priority="1.0">
+        <xsl:analyze-string select="." regex="[\n\s]+">
+            <xsl:matching-substring>
+                <xsl:value-of select="' '"/>
+            </xsl:matching-substring>
+            <xsl:non-matching-substring>
+                <xsl:apply-templates select="."/>
+            </xsl:non-matching-substring>
+        </xsl:analyze-string>
+    </xsl:template>
+    
     <xsl:template match="/">
         
         <xsl:message terminate="no" select="'INFO: Extracting Guidelines for publication from MEI source (version ' || $guidelines.version || ')'"/>


### PR DESCRIPTION
This template removes newline-characters from the plain-text results. This will result in the _include/desc/**.txt files being single-liners.