### PR TITLE
Fixed: Missing case for datatype

### DIFF
--- a/tools/extractGuidelines.xsl
+++ b/tools/extractGuidelines.xsl
@@ -1288,6 +1288,9 @@
             <xsl:when test="$data/@type = 'positiveInteger' and $data/rng:param[@name = 'maxInclusive']">
                 a positive integer no larger than <xsl:value-of select="$data/rng:param/text()"/>
             </xsl:when>
+            <xsl:when test="$data/@type = 'positiveInteger' and $data/rng:param[@name = 'minInclusive']">
+                a positive integer no smaller than <xsl:value-of select="$data/rng:param/text()" />
+            </xsl:when>
             <xsl:when test="$data/@type = 'nonNegativeInteger' and $data/rng:param[@name = 'maxInclusive']">
                 a non-negative integer no larger than <xsl:value-of select="$data/rng:param/text()"/>
             </xsl:when>


### PR DESCRIPTION
Previously the docs build would fail with an error:

ERROR: Cannot resolve the following datatype:
            <rng:param name="minInclusive">2</rng:param>

This commit fixes this error by adding a new case for positiveIntegers and minInclusive.