### PR TITLE
New: Include for embedding SMuFL glyphs

### DIFF
--- a/_guidelines-dev/08-cmnornaments/02-cmnornamentsmordents.md
+++ b/_guidelines-dev/08-cmnornaments/02-cmnornamentsmordents.md
@@ -15,10 +15,10 @@ It is recommended, but not required, to use the attribute **@form** to encode th
 The attribute **@form** accepts the following values:
 
 {:.gloss}
-**upper**: usually corresponding to the symbol: ![mordent](/guidelines/images/dev/modules/cmnOrnaments/upper_mordent.png). This mordent is commonly performed as the principal note, followed by its upper neighbor, with a return to the principal note.
+**upper**: usually corresponding to the symbol: {% include smufl code="E56C" %}. This mordent is commonly performed as the principal note, followed by its upper neighbor, with a return to the principal note.
 
 {:.gloss}
-**lower**: usually corresponding to the symbol: ![mordent](/guidelines/images/dev/modules/cmnOrnaments/lower_mordent.png). This mordent is commonly performed as the principal note, followed by its lower neighbor, with a return to the principal note.
+**lower**: usually corresponding to the symbol: {% include smufl code="E56D" %}. This mordent is commonly performed as the principal note, followed by its lower neighbor, with a return to the principal note.
 
 The following example demonstrates the encoding of simple mordents:
 

--- a/_includes/smufl
+++ b/_includes/smufl
@@ -1,0 +1,1 @@
+<img src="http://edirom.de/smufl-browser/{{ include.code }}.png" title="SMuFL glyph U+{{ include.code }}" style="width: 30px;"/>


### PR DESCRIPTION
The new include loads glyphs from the Edirom SMuFL Browser.

Refs #41