### PR TITLE
MEI 3.0 componentGrp => MEI 4.0 componentList

### DIFF
--- a/_includes/v4/examples/frbr/frbr-sample084.xml
+++ b/_includes/v4/examples/frbr/frbr-sample084.xml
@@ -2,7 +2,7 @@
    <titleStmt>
       <title>Der Ring des Nibelungen</title>
    </titleStmt>
-   <componentGrp>
+   <componentList>
       <work>
          <titleStmt>
             <title>Das Rheingold</title>
@@ -23,5 +23,5 @@
             <title>Götterdämmerung</title>
          </titleStmt>
       </work>
-   </componentGrp>
+   </componentList>
 </work>


### PR DESCRIPTION
Update example to use MEI4.0 componentList element (prose around this include on the frbr components page already talks about componentList, but the example still shows the old element)