### PR TITLE
adding general version warning to all chapters

### DIFF
--- a/_guidelines-v4/01-shared.md
+++ b/_guidelines-v4/01-shared.md
@@ -6,4 +6,6 @@ title: "Shared Elements, Models, and Attributes"
 sectionid: "shared"
 ---
 
+{% include version-warning %}
+
 This chapter describes the elements, models, and attributes that are part of the MEI.shared module. The shared module contains declarations that are common to two or more other modules.

--- a/_guidelines-v4/02-header.md
+++ b/_guidelines-v4/02-header.md
@@ -6,6 +6,8 @@ title: "The MEI Header"
 sectionid: "header"
 ---
 
+{% include version-warning %}
+
 This chapter addresses the description of an encoded item so that the musical text, as well as its sources, encoding, and revisions are all thoroughly documented. Such documentation is necessary for scholars using the texts, for software processing them, and for catalogers in libraries and archives. Together these descriptions and declarations provide an electronic analog to the title page attached to a printed work. They also constitute an equivalent for the content of the code books or introductory manuals customarily accompanying electronic data sets.
 
 Every MEI-conformant text not embedded in another XML carrier that provides for capturing metadata, such as TEI or METS, must carry a set of descriptions, prefixed to it and encoded as described in this chapter. This set is known as the MEI header, tagged {% include link elem="meiHead" %}, and has six major parts:

--- a/_guidelines-v4/03-frbr.md
+++ b/_guidelines-v4/03-frbr.md
@@ -6,6 +6,8 @@ title: "Functional Requirements for Bibliographic Records (FRBR)"
 sectionid: "FRBR"
 ---
 
+{% include version-warning %}
+
 MEI header information may refer to different levels of description of the encoded work: Some information may apply the work in all its various forms and realizations, e.g., the name of its composer. Other information may describe a certain version of the work, or a source such as the printed first edition, or only a single copy of that source. Core MEI limits the header information to two such levels of description: work and source, respectively.
 
 However, when the FRBR module is available more detailed descriptions are possible. With certain limitations, mainly due to the musical nature of the works encoded in MEI, the FRBR module adapts the Functional Requirements for Bibliographic Records (FRBR) as recommended by the International Federation of Library Associations and Institutions (IFLA) [[http://www.ifla.org/publications/functional-requirements-for-bibliographic-records](http://www.ifla.org/publications/functional-requirements-for-bibliographic-records){:.link_ref}].

--- a/_guidelines-v4/04-cmn.md
+++ b/_guidelines-v4/04-cmn.md
@@ -6,4 +6,6 @@ title: "Common Music Notation"
 sectionid: "cmn"
 ---
 
+{% include version-warning %}
+
 The module described in this chapter offers the means to describe music in so-called ‘Common Music Notation’ (CMN, sometimes referred to as ‘Common Western Music Notation’). For this purpose, it provides a number of special elements and adds several attribute classes to elements from the {% include link id="shared" %} module.

--- a/_guidelines-v4/05-mensural.md
+++ b/_guidelines-v4/05-mensural.md
@@ -6,6 +6,8 @@ title: "Mensural Notation"
 sectionid: "mensural"
 ---
 
+{% include version-warning %}
+
 This chapter describes the module for encoding mensural notation from the late 13th century to about 1600. Historically, mensural notation preceded the development of Common Music Notation (CMN) and it included a wide range of features that persist in CMN and that can be encoded in a standard manner in MEI. In mensural notation, pitches are notated as in CMN, leaving out here the major exception of *musica ficta*. The pitch is given by the position of the note on the staff and the current clef as in CMN, and the mensural module introduces no modification to MEI regarding how pitches are encoded.
 
 There are a certain number of differences, however, regarding the representation of duration in mensural notation. The mensural module introduces specific attribute values for notes and rests for appropriately encoding mensural durations. One of the main particularities is that the actual duration of a note is not given only by its symbol but also by position and the context in which the symbol appears. The general context is given by one of the 16 mensural *species* provide four levels of division: *modus major*, *modus minor*, *tempus* and *prolatio*. Depending on the context, certain rules must be applied in order to determine the duration of a note. In these cases, encoding both the sign and its actual duration is highy desirable.

--- a/_guidelines-v4/06-neumes.md
+++ b/_guidelines-v4/06-neumes.md
@@ -6,10 +6,6 @@ title: "Neume Notation"
 sectionid: "neumes"
 ---
 
----
-## This chapter describes an older version of the Neume encoding schema.
-
-Significant changes to the system of neume encoding were introduced in MEI v4. We're working on updating this documention, but would appreciate help. 
----
+{% include version-warning %}
 
 This chapter describes the elements, model classes, and attribute classes that are part of the MEI.neumes module.

--- a/_guidelines-v4/07-analysis.md
+++ b/_guidelines-v4/07-analysis.md
@@ -6,4 +6,6 @@ title: "Analytical Information"
 sectionid: "analysis"
 ---
 
+{% include version-warning %}
+
 This chapter describes the use of attributes that capture data which may be useful for analytical purposes. The analysis module provides attributes that record relationships between entities found in the encoding. These attributes may be used differently by different users, depending on the purpose of the analysis. These Guidelines recommend that encoders employ commonly accepted analytical practices, such as "functional analysis" or "Schenkerian analysis", and document their use in the {% include link elem="encodingDesc" %} described in section {% include link id="headerEncodingDescription" %}. For general information on musical analysis, please consult Grove Music Online, "[Analysis](https://doi.org/10.1093/gmo/9781561592630.article.41862){:.link_ref}".

--- a/_guidelines-v4/08-cmnornaments.md
+++ b/_guidelines-v4/08-cmnornaments.md
@@ -6,6 +6,8 @@ title: "Common Music Notation Ornaments"
 sectionid: "cmnOrnaments"
 ---
 
+{% include version-warning %}
+
 This module includes elements and attributes for the encoding of ornaments typical of ‘Common Music Notation’ (CMN). Ornaments are formulae of embellishment that can be realized by adding supplementary notes to one or more notes of the melody. In written form, these are usually expressed as symbols written above or below a note, though some have a more complex written expression, such as those that involve multiple notes and/or include grace notes.
 
 These symbols may have different resolutions depending on a large number of factors, such as historical context, national boundaries, composer, scribe, etc. The elements described here, therefore, are not bound to a specific symbol; they are, instead, meant to encode the encoder's interpretation of a symbol and its position on the staff.

--- a/_guidelines-v4/09-corpus.md
+++ b/_guidelines-v4/09-corpus.md
@@ -6,6 +6,8 @@ title: "Musical Corpora"
 sectionid: "corpus"
 ---
 
+{% include version-warning %}
+
 The term corpus may refer to any collection of musical data, although it is often reserved for collections which have been organized or collected with a particular end in view, generally to illustrate a particular characteristic of, or to demonstrate the variety found in, a group of related texts. The principal distinguishing characteristic of a corpus is that its components have been selected or structured according to some conscious set of design criteria.
 
 In MEI, a corpus is regarded as a composite text because, although each discrete document in a corpus clearly has a claim to be considered as a text in its own right, it is also regarded as a subdivision of some larger object, if only for convenience of analysis. In corpora, the component samples are clearly distinct texts, but the systematic collection, standardized preparation, and common markup of the corpus often make it useful to treat the entire corpus as a unit, too. Corpora share a number of characteristics with other types of composite texts, including anthologies and collections. Most notably, different components of composite texts may exhibit different structural properties, thus potentially requiring elements from different MEI modules.

--- a/_guidelines-v4/10-critapp.md
+++ b/_guidelines-v4/10-critapp.md
@@ -6,4 +6,6 @@ title: "Critical Apparatus"
 sectionid: "critApp"
 ---
 
+{% include version-warning %}
+
 This chapter describes how to encode differences between multiple exemplars of the same musical work (often referred to in MEI as ‘sources’). The mechanisms and elements described in this chapter are closely related to their counterparts in the TEI guidelines. It is also important to refer to chapter {% include link id="editTrans" %} of these guidelines, especially concerning the {% include link elem="choice" %} element described therein.

--- a/_guidelines-v4/11-edittrans.md
+++ b/_guidelines-v4/11-edittrans.md
@@ -6,6 +6,8 @@ title: "Editorial Markup"
 sectionid: "editTrans"
 ---
 
+{% include version-warning %}
+
 It is often necessary to render an account of any changes made to a musical text during its creation (and any subsequent editing) and to accommodate editorial comment necessitated by an editorial process. The elements and attributes described in this chapter may be used to record such editorial interventions, whether made by the composer, the copyists of the manuscript, the editor of a earlier edition used as a copy text, or the current encoder/editor.
 
 The scope of the elements described herein is therefore the description of features relating to the genesis, later revision and editorial interpretation of a text. Mechanisms for describing multiple sources are described in chapter {% include link id="critApp" %} of these Guidelines.

--- a/_guidelines-v4/12-facsimiles.md
+++ b/_guidelines-v4/12-facsimiles.md
@@ -6,4 +6,6 @@ title: "Facsimiles"
 sectionid: "facsimiles"
 ---
 
+{% include version-warning %}
+
 Most often, MEI is used for the preparation of a digital musical text based on an existing music document, or with the intention of rendering the encoded notation into a document or audio rendition. MEI can, however, be used to provide a different kind of digital reproduction of a source document, which relies on the description and provision of digital imagery. Both approaches may be combined, so that the encoding of the musical content and digital facsimiles may add different facets to the same MEI document.

--- a/_guidelines-v4/13-figtable.md
+++ b/_guidelines-v4/13-figtable.md
@@ -6,6 +6,8 @@ title: "Figures and Tables"
 sectionid: "figTable"
 ---
 
+{% include version-warning %}
+
 Apart from music and text, musical documents, both historical and contemporary, may also contain material in graphical or tabular format. In such materials, details of layout and presentation may also be of comparatively greater significance or complexity than they are for running text. Although some types of graphical material can be represented directly with markup, it is more common practice to include such information by using a reference to an external entity (typically a URL) encoded in a suitable graphical format.
 
 The module defined by this chapter defines special purpose ‘container’ elements that can be used to encapsulate occurrences of such data within an MEI-conformant document in a portable way. Specific recommendations for the encoding of figures, figure descriptions and graphics as well as tables with their sub-elements {% include link elem="tr" %}, {% include link elem="td" %} and {% include link elem="th" %} are provided at the beginnig of this chapter. As there exists a wide variety of different graphic formats, a short list of formats that are widely used at the present time, is given in section {% include link id="figTableImages" %}. Each one includes a very brief description. The chapter closes with attribute and model classes which are defined by the module.

--- a/_guidelines-v4/14-harmony.md
+++ b/_guidelines-v4/14-harmony.md
@@ -6,4 +6,6 @@ title: "Harmony"
 sectionid: "harmony"
 ---
 
+{% include version-warning %}
+
 This chapter describes the encoding of indications of harmony ocurring within a music text, e.g., chord names, tablature grids, figured bass, or signs for harmonic analysis, and the methods by which these indications can be connected with their interpretations. For encoder-supplied analysis of intervallic content, please see chapter {% include link id="analysis" %}.

--- a/_guidelines-v4/15-lyricsdesc.md
+++ b/_guidelines-v4/15-lyricsdesc.md
@@ -6,6 +6,8 @@ title: "Vocal Text"
 sectionid: "lyricsDesc"
 ---
 
+{% include version-warning %}
+
 This chapter describes how to encode words and syllables in vocal notation. This text is typically written under a staff to indicate the text to be vocally performed. As such, this text should not be confused with other text on the score, for which see {% include link id="sharedTextualElements" %} and {% include link id="text" %}
 
 These guidelines suggest two methods for encoding text in vocal notation: encoding syllables {% include link id="lyricsInEvents" %} and encoding performed text {% include link id="lyricsAfterEvents" %} (and other staff events) either within {% include link elem="layer" %} elements or within {% include link elem="measure" %} elements when available (for example in a Common Music Notation context). Each method may be more convenient depending on the source text and on the textual phenomena that the encoding intends to record.

--- a/_guidelines-v4/16-midiguidelines.md
+++ b/_guidelines-v4/16-midiguidelines.md
@@ -6,6 +6,8 @@ title: "Musical Instrument Digital Interface (MIDI)"
 sectionid: "midiGuidelines"
 ---
 
+{% include version-warning %}
+
 This chapter describes the MIDI encoding functionality present in MEI. The purpose of this module is to allow for integrating MIDI data into MEI-encoded notation, to both aid software in translating MEI to MIDI, and to permit the capture of information in files that have been translated from MIDI to MEI. The MIDI model in MEI is similar to that of Mup, and the user is directed to the [Mup User Guide](http://www.arkkra.com/doc/uguide.ps){:.link_ref} for further reading.
 
 The MIDI module defines certain generally-accepted MIDI units that may be used outside of a MIDI context. For example, the **@dur.ges** attribute accepts MIDI **ppq** (Pulses Per Quarter) as a valid measurement of duration. Similarly, the **@pnum** attribute allows MIDI note numbers for specifying a pitch value.

--- a/_guidelines-v4/17-namesdates.md
+++ b/_guidelines-v4/17-namesdates.md
@@ -6,6 +6,8 @@ title: "Names and Dates"
 sectionid: "namesDates"
 ---
 
+{% include version-warning %}
+
 This chapter describes the MEI module used for the encoding of names (names of persons or corporations/organizations) or descriptive phrases for styles, periods or geographical indications. In section {% include link id="sharedNamesNumbersDates" %} it was noted that the elements provided in the core module allow an encoder to specify that a given text segment is a proper noun. The elements provided by the present module allow the encoder to supply a detailed sub-structure for such proper nouns, and to distinguish explicitly between persons and organizations, and between stylistic, periodical or geographical indications.
 
 The chapter begins by discussing the elements provided for the encoding of names ({% include link elem="name" %}) and dates ({% include link elem="date" %}) in general and finishes by addressing more specific elements for corporate names ({% include link elem="corpName" %}), geographic names ({% include link elem="geogName" %}), period names ({% include link elem="periodName" %}), personal names ({% include link elem="persName" %}) and style names ({% include link elem="styleName" %}). In general it is recommended to use standardized forms of proper nouns and to record the names and web-accessible locations of the controlled vocabularies used. There are several commonly-referenced authority files, especially for geographical, organizational and personal names, such as the Gemeinsame Normdatei (GND), the Library of Congress Authorities, the Getty Thesaurus of Geographic Names (TGN), and the MARC code list for relators. Recommendations on which standards could be used can be found in the descriptions of the individual elements.

--- a/_guidelines-v4/18-performances.md
+++ b/_guidelines-v4/18-performances.md
@@ -6,4 +6,6 @@ title: "Performances"
 sectionid: "performances"
 ---
 
+{% include version-warning %}
+
 This chapter describes the ‘performance’ module, which can be used for organizing audio and video files of performances of a musical work. The elements provided allow the encoder to group different recordings of the same performance, identify temporal segments within the recordings, and encode simple alignments with a music text.

--- a/_guidelines-v4/19-ptrref.md
+++ b/_guidelines-v4/19-ptrref.md
@@ -6,4 +6,6 @@ title: "Pointers and References"
 sectionid: "ptrRef"
 ---
 
+{% include version-warning %}
+
 This chapter describes the use of elements for linking and referencing.

--- a/_guidelines-v4/20-tablature.md
+++ b/_guidelines-v4/20-tablature.md
@@ -6,4 +6,6 @@ title: "Tablature Notation"
 sectionid: "tablature"
 ---
 
+{% include version-warning %}
+
 This chapter describes the attribute classes that are part of the MEI.tablature module.

--- a/_guidelines-v4/21-text.md
+++ b/_guidelines-v4/21-text.md
@@ -6,6 +6,8 @@ title: "Text in MEI"
 sectionid: "text"
 ---
 
+{% include version-warning %}
+
 This chapter describes methods for encoding textual content with MEI. Textual information on scores has several different uses, although some text is closer to music notation than other kinds. For example, tempo marks, directives and lyrics are directly related to the functionality of the notated music and are, therefore, described in other chapters (see for example {% include link id="lyricsDesc" %} and {% include link id="sharedTextDirectives" %}). This chapter, on the other hand, focuses on the text that accompanies the score, i.e., paratext (prefatory material, title pages, back matter, appendices, etc.), titles, prose, poetry, etc.
 
 Most of the elements described here take inspiration from encoding formats that deal primarily with text, such as HTML and the Text Encoding Initiative (TEI). These elements are provided to encode relatively basic textual information. For deeper encoding of text, these Guidelines recommend consideration of other text-specific encoding formats with embedded MEI markup.

--- a/_guidelines-v4/22-usersymbols.md
+++ b/_guidelines-v4/22-usersymbols.md
@@ -6,4 +6,6 @@ title: "User-defined Symbols"
 sectionid: "userSymbols"
 ---
 
+{% include version-warning %}
+
 This chapter describes the elements, model classes, and attribute classes that are part of the MEI.usersymbols module.

--- a/_guidelines-v4/23-linkalign.md
+++ b/_guidelines-v4/23-linkalign.md
@@ -6,4 +6,6 @@ title: "Linking and Alignment"
 sectionid: "linkAlign"
 ---
 
+{% include version-warning %}
+
 The linkAlign module makes it possible to align recorded media (audio, video) with elements in the musical domain. This allows for synchronization between the encoded notation and one or many media.

--- a/_includes/version-warning
+++ b/_includes/version-warning
@@ -19,6 +19,6 @@
         This Chapter of the MEI Guidelines is outdated and reflects the older state of the MEI v3 release. 
         It may contradict the current state of the MEI specifications as documented in the Elements, 
         Attribute Classes, Model Classes, Data Types and Macro Groups sections. The Community is currently 
-        working to update these Guidelines. Of course, help is greatly appreciated. In that case, please 
+        working to update these Guidelines. Of course, help is greatly appreciated. In case you would like to contribute, please 
         <a href="https://music-encoding.org/community/community-contacts.html">reach out to us</a>.</p>
 </div>

--- a/_includes/version-warning
+++ b/_includes/version-warning
@@ -1,0 +1,24 @@
+<style type="text/css">
+    .disclaimer {
+        border: 1px solid #000000;
+        border-radius: 10px;
+        margin: 10px 50px 40px;
+        padding: 20px;
+        background-color: #ffbc41;
+    }
+    .heading {
+        font-weight: 700;
+        font-size: 1.4em;
+        padding: 0 0 .3em;
+    }
+</style>
+
+<div class="disclaimer">
+    <div class="heading">Attention</div>
+    <p>
+        This Chapter of the MEI Guidelines is outdated and reflects the older state of the MEI v3 release. 
+        It may contradict the current state of the MEI specifications as documented in the Elements, 
+        Attribute Classes, Model Classes, Data Types and Macro Groups sections. The Community is currently 
+        working to update these Guidelines. Of course, help is greatly appreciated. In that case, please 
+        <a href="https://music-encoding.org/community/community-contacts.html">reach out to us</a>.</p>
+</div>


### PR DESCRIPTION
This PR adds a generic warning to every chapter of the Guidelines, replacing the single statement added in c3c0f89e6f05bbcc1eec7c421b81193ac1a43e89. It should be removed as soon as a chapter has been cleaned. The attached screenshot shows the layout. It would be good if someone could have a look at the text. That would have to be updated in /_includes/version-warning. Thanks :-)



<img width="875" alt="Bildschirmfoto 2019-03-20 um 16 48 47" src="https://user-images.githubusercontent.com/2078563/54699012-8b5aae00-4b30-11e9-99f0-9e5ae22b8bf0.png">
