### PR TITLE
Missed wrong attribute names

### DIFF
--- a/_guidelines-v4/04-cmn/01-cmnbasics/04-cmnnoteschords/01-cmnnotes/03-cmnnotesstems.md
+++ b/_guidelines-v4/04-cmn/01-cmnbasics/04-cmnnoteschords/01-cmnnotes/03-cmnnotesstems.md
@@ -32,7 +32,7 @@ The **@stem.mod** attribute accommodates various stem modifiers found in the CMN
 
 The **@stem.mod** attibute is normally used in accordance with practices described in section {% include link id="cmnTrem" %}.
 
-The CMN module makes the {% include link att="att.stems.cmn" %} attribute class available, which adds the optional **@stem.with** attribute to {% include link elem="note" %} and {% include link elem="chord" %}. The attribute **@stem.with** allows for the indication of a stem that joins notes on adjacent staves.
+The CMN module makes the {% include link att="stems.cmn" %} attribute class available, which adds the optional **@stem.with** attribute to {% include link elem="note" %} and {% include link elem="chord" %}. The attribute **@stem.with** allows for the indication of a stem that joins notes on adjacent staves.
 
 {% include figure img="modules/cmn/xchord-300.png" caption="Cross-staff chord" %}
 

--- a/_guidelines-v4/12-facsimiles/01-facsimileelements.md
+++ b/_guidelines-v4/12-facsimiles/01-facsimileelements.md
@@ -40,7 +40,7 @@ A {% include link elem="zone" %} element may contain {% include link elem="figDe
 
 {% include mei example="facsimiles/facsimiles-sample250.xml" valid="feasible" %}
 
-Conversely, an element in the content may refer to the {% include link elem="facsimile" %} subtree using its **@facs** attribute, which is made available by the {% include link att="att.facsimile" %} attribute class. The last example could therefore be encoded with pointers in the other direction:
+Conversely, an element in the content may refer to the {% include link elem="facsimile" %} subtree using its **@facs** attribute, which is made available by the {% include link att="facsimile" %} attribute class. The last example could therefore be encoded with pointers in the other direction:
 
 {% include mei example="facsimiles/facsimiles-sample251.xml" valid="feasible" %}
 


### PR DESCRIPTION
 (see 839c5a5d7f11d5f9a0deecb9fb612e0ca07f9faf)