### PR TITLE
Add links to include desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Windows user should check out this step-by-step guide to setting up Jekyll on Wi
 
 ### Step 4. Run the Jekyll server
 
-You can run the Jekyll service locally with `bundle exec jekyll serve --baseurl=""`. This will compile the site and start serving the content locally. Once it's ready, you can open your browser and visit `http://localhost:4000` to see your local version of the site.
+You can run the Jekyll service locally with `bundle exec jekyll serve --baseurl=""`. This will compile the site and start serving the content locally. Since compiling can take a while, you can add the option `-V` to get a more verbose output and information about the running compilation steps. Once it's ready, you can open your browser and visit `http://localhost:4000` to see your local version of the site.
 
 ### Step 5. Make your changes and commit
 

--- a/_includes/desc-item
+++ b/_includes/desc-item
@@ -7,9 +7,9 @@
     <div class="tile-content">
         <div class="tile-title">
             {% if include.att %}
-                @{{ include.att | split: '/' | last }}
+                <a href="{{ site.baseurl }}/{{ include.version }}/attribute-classes/{{ include.att | split: '/' | first | downcase }}.html">@{{ include.att | split: '/' | last }}</a>
             {% else %}  
-                {{ include.elem }}
+                <a href="{{ site.baseurl }}/{{ include.version }}/elements/{{ include.elem | downcase }}.html">{{ include.elem }}</a>
             {% endif %}
         </div>
         <div class="tile-subtitle text-gray">


### PR DESCRIPTION
This PR adds links to the titles of the include template `desc-item` to connect them with the respective page for elements or in case of attributes for their resp. attribute-classes. The links respect the guideline's version as well, so it works with v4 and v3.

Fixes #100 

Additionally, it adds a hint to the `README` about the verbose option `-V` when generating the guidelines locally.

