### PR TITLE
When using private use area codepoints, say that it's SMuFL

### DIFF
--- a/_includes/v4/examples/cmnornaments/cmnornaments-sample208.txt
+++ b/_includes/v4/examples/cmnornaments/cmnornaments-sample208.txt
@@ -1,1 +1,4 @@
-<ornam tstamp="1">&amp;#xe5c0;</ornam>
+<ornam tstamp="1">
+  <symbol glyph.auth="smufl" glyph.num="#xE5C0"
+    glyph.name="ornamentPrecompDoubleCadenceLowerPrefix"/>
+</ornam>


### PR DESCRIPTION
Private use are codepoints are used for different purposes (for example by the [Medieval Unicode Font Initiative](https://en.wikipedia.org/wiki/Medieval_Unicode_Font_Initiative), so better instruct people to make clear it's SMuFL.