### PR TITLE
Correct @tstamp2 of trills

### DIFF
--- a/_includes/v4/examples/cmnornaments/cmnornaments-sample187.txt
+++ b/_includes/v4/examples/cmnornaments/cmnornaments-sample187.txt
@@ -9,5 +9,5 @@
       </beam>
     </layer>
   </staff>
-  <trill ho="+1" place="above" staff="1" tstamp="1" tstamp2="2.5" vo="6.5"/>
+  <trill ho="+1" place="above" staff="1" tstamp="1" tstamp2="3" vo="6.5"/>
 </measure>

--- a/_includes/v4/examples/cmnornaments/cmnornaments-sample200.txt
+++ b/_includes/v4/examples/cmnornaments/cmnornaments-sample200.txt
@@ -11,5 +11,5 @@
       </graceGrp>
     </layer>
   </staff>
-  <trill place="above" staff="1" tstamp="1" tstamp2="2.5" vo="6.5"/>
+  <trill place="above" staff="1" tstamp="1" tstamp2="3" vo="6.5"/>
 </measure>


### PR DESCRIPTION
Trills for notes at `@tstamp="1"` and `@dur="2"` should have `@tstamp2="3"` (`@tstamp` + `@dur`), right?