### PR TITLE
Application independent symbol encoding

### DIFF
--- a/mei/v4/tempo-01.mei
+++ b/mei/v4/tempo-01.mei
@@ -42,9 +42,9 @@
                                     </beam>
                                 </layer>
                             </staff>
-                            <tempo tstamp="1" staff="1">Andante con moto <rend
-                                    fontname="VerovioText">&#xE1D3;</rend> = 70 </tempo>
-                        	
+                            <tempo tstamp="1" staff="1">Andante con moto <symbol glyph.auth="smufl" 
+                                glyph.num="#xE1D3" glyph.name="noteHalfUp"/> = 70 </tempo>
+
                             <slur startid="#m0_s2_e1" endid="#m0_s2_e2"/>
                         </measure>
                     	<?edit-end?>


### PR DESCRIPTION
Probably this is not a pull request to merge right away but to discuss.

I don't think it's advisable to encode symbols as in the current example:

    <tempo tstamp="1" staff="1">Andante con moto <rend
            fontname="VerovioText">&#xE1D3;</rend> = 70 </tempo>

That's specific to Verovio – I think it would be cleaner like this:

    <tempo tstamp="1" staff="1">Andante con moto <symbol glyph.auth="smufl" 
        glyph.num="#xE1D3" glyph.name="noteHalfUp"/> = 70 </tempo>

This is however not (yet) supported by Verovio and the really neat mechanisms to include Verovio examples in the guidelines can't be used.