### PR TITLE
Update 01-midi.scoredefppq.md

### DIFF
--- a/_guidelines-dev/14-integration/05-midiguidelines/01-midi.scoredefppq.md
+++ b/_guidelines-dev/14-integration/05-midiguidelines/01-midi.scoredefppq.md
@@ -4,7 +4,7 @@ title: "PPQ in scoreDef and staffDef"
 version: "dev"
 ---
 
-To define the MIDI resolution of a score, the **@ppq** attribute may be used on the {% include link elem="scoreDef" %} element. This value can be used to interpret the values found in the **@dur.ges** attribute on elements in the {% include link att="duration.gestural" %} class.
+To define the MIDI resolution of a score, the **@ppq** attribute may be used on the {% include link elem="scoreDef" %} element. This value can be used to interpret the values found in the **@dur.ppq** attribute on elements in the {% include link att="duration.gestural" %} class.
 
 {% include mei example="midiGuidelines/midiGuidelines-sample286.xml" valid="feasible" %}
 


### PR DESCRIPTION
ppq values are now encoded in `@dur.ppq` and not in `@dur.ges` anymore.