### PR TITLE
Documentation for the `@rotate` attribute

### DIFF
--- a/_guidelines-v4/12-facsimilesrecordings/01-facsimiles/01-facsimileelements.md
+++ b/_guidelines-v4/12-facsimilesrecordings/01-facsimiles/01-facsimileelements.md
@@ -36,6 +36,11 @@ Because the coordinate space of a zone is defined relative to that of a surface,
 
 {% include mei example="facsimiles/facsimiles-sample249.xml" valid="" %}
 
+Additionally, the area represented by a {% include link elem="zone" %} element may not be normally oriented to its parent surface. The amount by which the area has been rotated clockwise in degrees is expressed by the **@rotate** attribute. By default this amount is 0&deg;.
+For a zone where its contents are oriented 90&deg; clockwise:
+
+{% include mei example="facsimiles/facsimiles-sample-rotate.xml" valid="" %}
+
 A {% include link elem="zone" %} element may contain {% include link elem="figDesc" %} or {% include link elem="graphic" %} elements that provide detailed descriptive information about the zone and additional images, e.g., at a different/higher resolution, of the rectangle defined by the zone. The data objects contained within the zone may also be specified through the use of the **@data** attribute, which contains ID references to one more elements in the content tree of the MEI file, such as a {% include link elem="note" %}, {% include link elem="measure" %}, etc.
 
 {% include mei example="facsimiles/facsimiles-sample250.xml" valid="feasible" %}

--- a/_guidelines-v4/12-facsimilesrecordings/01-facsimiles/01-facsimileelements.md
+++ b/_guidelines-v4/12-facsimilesrecordings/01-facsimiles/01-facsimileelements.md
@@ -36,8 +36,9 @@ Because the coordinate space of a zone is defined relative to that of a surface,
 
 {% include mei example="facsimiles/facsimiles-sample249.xml" valid="" %}
 
-Additionally, the area represented by a {% include link elem="zone" %} element may not be normally oriented to its parent surface. The amount by which the area has been rotated clockwise in degrees is expressed by the **@rotate** attribute. By default this amount is 0&deg;.
-For a zone where its contents are oriented 90&deg; clockwise:
+The amount by which contents of an element have been rotated clockwise or, if applicable, how the orientation of the element itself should be interpreted, is indicated by the **@rotate** attribute.
+This amount is with respect to the normal orientation of the parent surface and is expressed in arc degrees. By default, this amount is 0&deg;, following the same orientation as the parent.
+For example, the following would encode a zone where its contents are oriented 90&deg; clockwise:
 
 {% include mei example="facsimiles/facsimiles-sample-rotate.xml" valid="" %}
 

--- a/_includes/v4/examples/facsimiles/facsimiles-sample-rotate.xml
+++ b/_includes/v4/examples/facsimiles/facsimiles-sample-rotate.xml
@@ -1,0 +1,3 @@
+<surface>
+    <zone lrx="370" lry="410" ulx="300" uly="200" rotate="90"></zone>
+</surface>


### PR DESCRIPTION
Add basic documentation to the facsimile documentation mentioning the `@rotate` attribute, which follows from [the TEI attribute of the same name](https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-zone.html). This corresponds to the changes in the schema PR music-encoding/music-encoding#674.