### PR TITLE
Corrections to ossia examples

### DIFF
--- a/_includes/v4/examples/cmn/cmn-sample157.txt
+++ b/_includes/v4/examples/cmn/cmn-sample157.txt
@@ -3,9 +3,9 @@
     <!-- first staff, without ossia -->
   </staff>
   <ossia>
-    <staff>
+    <oStaff>
       <!-- alternative content on reduced-size staff -->
-    </staff>
+    </oStaff>
     <staff n="2">
       <!-- original content on regular staff -->
     </staff>

--- a/_includes/v4/examples/cmn/cmn-sample158.txt
+++ b/_includes/v4/examples/cmn/cmn-sample158.txt
@@ -7,9 +7,9 @@
       <layer n="1">
         <!-- original content in regular layer -->
       </layer>
-      <layer>
+      <oLayer>
         <!-- alternative content in separate layer -->
-      </layer>
+      </oLayer>
     </ossia>
   </staff>
   <staff n="3">


### PR DESCRIPTION
Ossay staffs/layers need the `<oStaff>` and  `<oLayer>` elements.