### PR TITLE
Fix: Encoding three-note raising gesture.

### DIFF
--- a/_includes/v4/examples/neumes/neumes-sample-6-03-01.xml
+++ b/_includes/v4/examples/neumes/neumes-sample-6-03-01.xml
@@ -1,4 +1,5 @@
 <neume>
+  <nc/>
   <nc>
     <oriscus/>
   </nc>


### PR DESCRIPTION
This change fixes the encoding of Example 1 St. Gall notation and Example 2 Aquitanian notation.

The change was discussed with @elsinhadl and @fujinaga