### PR TITLE
Update Chapter 05 (dev) - Repertoire - Mensural Notation

### DIFF
--- a/_guidelines-dev/05-mensural/02-mensuralsigns.md
+++ b/_guidelines-dev/05-mensural/02-mensuralsigns.md
@@ -10,14 +10,16 @@ The division levels corresponding to *modus maior*, *modus minor*, *tempus*, and
 
 The mensur signs themselves can be encoded in the **@mensur.sign** attribute with a possible value of "C" or "O". Its orientation can be encoded in the **@mensur.orient** attribute, for example, with the value "reversed" for a flipped C sign. The number of slashes (up to 6) can be given in the **@mensur.slash** attribute. There is also a **@mensur.dot** attribute for indicating the presence of a dot through the boolean values "true" or "false".
 
-The mensuration values encoded in {% include link elem="staffDef" %} are meant to indicate the mensuration of the voice. The {% include link elem="mensur" %} element allows to encode changes in mensuration within the voice. For this purpose, the {% include link elem="mensur" %} element must be located within the {% include link elem="layer" %} element, preceding the stream of notes to be affected by the new mensuration defined by it.
+{% include link elem="mensur" %} elements can also be used instead of {% include link elem="staffDef" %} and its attributes. In {% include link elem="mensur" %}, the division levels are encoded with the previously mentioned **@modusmaior**, **@modusminor**, **@tempus**, and **@prolatio** attributes, while the attributes to indicate the mensur signs are: **@sign**, **@orient**, **@slash**, and **@dot**. {% include link elem="mensur" %} can be a child of the {% include link elem="staffDef" %} and {% include link elem="layer" %} elements.
 
 {% include desc elem="mensur" %}
 
-In {% include link elem="mensur" %}, the division levels are encoded with the previously mentioned **@modusmaior**, **@modusminor**, **@tempus**, and **@prolatio** attributes, while the attributes to indicate the mensur signs are: **@sign**, **@orient**, **@slash**, and **@dot**.
+##### Change in mensuration
 
-The following example illustrates a **change in mensuration**.
+The following example illustrates a **change in mensuration**. In this case, the element {% include link elem="mensur" %} is used within the {% include link elem="layer" %} element,  preceding the stream of notes affected by the new mensuration defined by it.
 {% include verovio example="mensuration_changes.mei" encoding=true %}
+
+##### Implicit mensuration
 
 It is common in *Ars antiqua* and some *Ars nova* pieces to have no mensuration signs. In this case, the mensuration—the division levels corresponding to *modus maior*, *modus minor*, *tempus*, and *prolatio*—is given by the context. The next example shows the incipit of a four-voice piece, Josquin's *Tu solus qui facis mirabilia*, where only two of the voices (*Cantus* and *Tenor*) have a mensuration sign. The other two (*Altus* and *Bassus*) have **no mensuration signs**, and the **mensura is given by the context**. Therefore, while only the *Cantus* and the *Tenor* have attributes for encoding the mensuration sign (in this case, **@mensur.sign** and **@mensur.slash**), all four voices include attributes to encode the *mensura* (**@tempus** and **@prolatio**).
 {% include verovio example="implicit-mensuration.mei" encoding=true %}

--- a/_guidelines-dev/05-mensural/02-mensuralsigns.md
+++ b/_guidelines-dev/05-mensural/02-mensuralsigns.md
@@ -4,22 +4,20 @@ title: "Mensuration"
 version: "dev"
 ---
 
-When using the mensural module, mensuration can be indicated with the attributes available on the {% include link elem="mensur" %} element. The {% include link elem="mensur" %} element must be located within the {% include link elem="layer" %} element, preceding the stream of notes to be affected by the mensuration defined by it.
-
-{% include desc elem="mensur" %}
+Using the mensural module, mensuration signs can be indicated with the attributes available on the {% include link elem="scoreDef" %} and {% include link elem="staffDef" %} elements. Mensuration signs encoded using attributes on {% include link elem="scoreDef" %} are regarded as default values which may be overridden by values attached to individual {% include link elem="staffDef" %} elements.
 
 The division levels corresponding to *modus maior*, *modus minor*, *tempus*, and *prolatio* can be encoded in the **@modusmaior**, **@modusminor**, **@tempus**, and **@prolatio** attributes respectively. Their value must be 3 (perfect) or 2 (imperfect).
 
-{% include desc atts="att.mensural.shared/modusmaior att.mensural.shared/modusminor att.mensural.shared/tempus att.mensural.shared/prolatio" %}
+The mensur signs themselves can be encoded in the **@mensur.sign** attribute with a possible value of "C" or "O". Its orientation can be encoded in the **@mensur.orient** attribute, for example, with the value "reversed" for a flipped C sign. The number of slashes (up to 6) can be given in the **@mensur.slash** attribute. There is also a **@mensur.dot** attribute for indicating the presence of a dot through the boolean values "true" or "false".
 
-The mensuration signs themselves can be encoded in the **@sign** attribute with a possible value of "C" or "O". Its orientation can be encoded in the **@orient** attribute, for example, with the value "reversed" for a flipped C sign. The number of slashes (up to 6) can be given in the **@slash** attribute. There is also a **@dot** attribute for indicating the presence of a dot.
+The mensuration values encoded in {% include link elem="staffDef" %} are meant to indicate the mensuration of the voice. The {% include link elem="mensur" %} element allows to encode changes in mensuration within the voice. For this purpose, the {% include link elem="mensur" %} element must be located within the {% include link elem="layer" %} element, preceding the stream of notes to be affected by the new mensuration defined by it.
 
-{% include desc atts="att.mensur.log/dot att.mensur.log/sign att.slashCount/slash att.mensur.vis/orient" %}
+{% include desc elem="mensur" %}
 
-<!-- In the first two attributes, the 'att.mensur.log' has to be changed into 'att.mensur.vis' once the changes in the schema regarding the encoding of the mensuration signs in the visual domain gets accepted -->
+In {% include link elem="mensur" %}, the division levels are encoded with the previously mentioned **@modusmaior**, **@modusminor**, **@tempus**, and **@prolatio** attributes, while the attributes to indicate the mensur signs are: **@sign**, **@orient**, **@slash**, and **@dot**.
 
-The following example illustrates a **change in mensuration**. As can be seen in the code snippet, the two mensuration signs are encoded in the stream of notes. In other words, the two {% include link elem="mensur" %} elements encoding each mensuration sign are located in the stream of {% include link elem="note" %} and {% include link elem="rest" %} elements inside the {% include link elem="layer" %}.
+The following example illustrates a **change in mensuration**.
 {% include verovio example="mensuration_changes.mei" encoding=true %}
 
-It is common in *Ars antiqua* and some *Ars nova* pieces to have no mensuration signs. In this case, the mensuration—the division levels corresponding to *modus maior*, *modus minor*, *tempus*, and *prolatio*—is given by the context. The next example shows the incipit of a four-voice piece, Josquin's *Tu solus qui facis mirabilia*, where only two of the voices (*Cantus* and *Tenor*) have a mensuration sign. The other two (*Altus* and *Bassus*) have **no mensuration signs**, and the **mensura is given by the context**. Therefore, while only the *Cantus* and the *Tenor* have attributes for encoding the mensuration sign (**@sign** and **@slash**), all four voices include attributes to encode the *mensura* (**@tempus** and **@prolatio**).
+It is common in *Ars antiqua* and some *Ars nova* pieces to have no mensuration signs. In this case, the mensuration—the division levels corresponding to *modus maior*, *modus minor*, *tempus*, and *prolatio*—is given by the context. The next example shows the incipit of a four-voice piece, Josquin's *Tu solus qui facis mirabilia*, where only two of the voices (*Cantus* and *Tenor*) have a mensuration sign. The other two (*Altus* and *Bassus*) have **no mensuration signs**, and the **mensura is given by the context**. Therefore, while only the *Cantus* and the *Tenor* have attributes for encoding the mensuration sign (in this case, **@mensur.sign** and **@mensur.slash**), all four voices include attributes to encode the *mensura* (**@tempus** and **@prolatio**).
 {% include verovio example="implicit-mensuration.mei" encoding=true %}

--- a/_guidelines-dev/05-mensural/03-mensuralproportions.md
+++ b/_guidelines-dev/05-mensural/03-mensuralproportions.md
@@ -4,6 +4,6 @@ title: "Proportions"
 version: "dev"
 ---
 
-Proportions can also be indicated within the {% include link elem="mensur" %} element. The **@num** and **@numbase** attributes are available for encoding the numerator and the denominator of the proportion, respectively. There is also a {% include link elem="proport" %} element that can be used as an alternative.
+Proportions can also be indicated within the {% include link elem="staffDef" %} element. The **@proport.num** and **@proport.numbase** attributes are available for encoding the numerator and the denominator of the proportion, respectively. There is also a {% include link elem="proport" %} element that can be used as an alternative, with the corresponding **@num** and **@numbase** attributes.
 
 {% include desc elem="proport" %}

--- a/_includes/dev/examples/mensural/mensural-sample153.xml
+++ b/_includes/dev/examples/mensural/mensural-sample153.xml
@@ -1,5 +1,5 @@
+<!--With @modusminor equal to "3" in the <staffDef> element-->
 <layer n="1">
-    <mensur modusminor="3" tempus="3"/>
     <!--First system in the image-->
     ...
     <rest dur="2B"/>

--- a/_includes/dev/examples/mensural/mensural-sample164.xml
+++ b/_includes/dev/examples/mensural/mensural-sample164.xml
@@ -1,5 +1,5 @@
+<!--With @modusminor equal to "3" in the <staffDef> element-->
 <layer>
-    <mensur modusminor="3"/>
     <note dur="longa"/>
     <note dur="brevis"/>
     <note dur="brevis" dur.quality="altera"/>

--- a/_includes/dev/examples/mensural/mensural-sample165.xml
+++ b/_includes/dev/examples/mensural/mensural-sample165.xml
@@ -1,5 +1,5 @@
+<!--With @modusminor and @tempus equal to "3" in the <staffDef> element-->
 <layer>
-    <mensur modusminor="3" tempus="3"/>
     <note dur="longa"/>
     <note dur="semibrevis"/>
     <note dur="semibrevis"/>

--- a/mei/dev/alteration.mei
+++ b/mei/dev/alteration.mei
@@ -34,7 +34,7 @@
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>
                                 <barLine form="dashed"/>
-                                <note dur="brevis" dur.quality="altera" num="1" numbase="2"/>
+                                <note dur="brevis" dur.quality="altera"/>
                                 <barLine form="dashed"/>
                                 <note dur="longa" dur.quality="perfecta"/>
                                 <barLine form="dashed"/>

--- a/mei/dev/alteration.mei
+++ b/mei/dev/alteration.mei
@@ -21,15 +21,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="3"/>
                                 <note dur="longa" dur.quality="perfecta"/>
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>
@@ -43,7 +42,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="3"/>
                                 <note dur="brevis" pname="a" oct="4"/>
                                 <note dur="brevis" pname="a" oct="4"/>
                                 <note dur="brevis" pname="a" oct="4"/>

--- a/mei/dev/ars_antiqua.mei
+++ b/mei/dev/ars_antiqua.mei
@@ -20,15 +20,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="3" tempus="3"/>
                                 <note dur="longa" dur.quality="perfecta"/>
                                 <barLine form="dashed"/>
                                 <note dur="semibrevis" dur.quality="minor"/>
@@ -48,7 +47,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="3" tempus="3"/>
                                 <note dur="brevis"/>
                                 <note dur="brevis"/>
                                 <note dur="brevis"/>

--- a/mei/dev/ars_antiqua.mei
+++ b/mei/dev/ars_antiqua.mei
@@ -37,11 +37,11 @@
                                 <dot form="div"/>
                                 <barLine form="dashed"/>
                                 <note dur="semibrevis" dur.quality="minor"/>
-                                <note dur="semibrevis" dur.quality="maior" num="1" numbase="2"/>
+                                <note dur="semibrevis" dur.quality="maior"/>
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>
                                 <barLine form="dashed"/>
-                                <note dur="longa" dur.quality="duplex" num="1" numbase="2"/>
+                                <note dur="longa" dur.quality="duplex"/>
                                 <barLine form="dashed"/>
                             </layer>
                             <?edit-end?>

--- a/mei/dev/augmentation.mei
+++ b/mei/dev/augmentation.mei
@@ -29,7 +29,7 @@
                             <?edit-start?>
                             <layer>
                                 <mensur modusminor="2" tempus="2"/>
-                                <note dur="longa" dur.quality="perfecta" num="2" numbase="3"/>
+                                <note dur="longa" dur.quality="perfecta"/>
                                 <dot form="aug"/>
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>

--- a/mei/dev/augmentation.mei
+++ b/mei/dev/augmentation.mei
@@ -20,15 +20,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="2" tempus="2"/>
                                 <note dur="longa" dur.quality="perfecta"/>
                                 <dot form="aug"/>
                                 <barLine form="dashed"/>
@@ -39,7 +38,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="2" tempus="2"/>
                                 <note dur="brevis" pname="a" oct="4"/>
                                 <note dur="brevis" pname="a" oct="4"/>
                                 <note dur="brevis" pname="a" oct="4"/>

--- a/mei/dev/imperfection.mei
+++ b/mei/dev/imperfection.mei
@@ -30,14 +30,14 @@
                             <?edit-start?>
                             <layer>
                                 <mensur modusminor="3"/>
-                                <note dur="longa" dur.quality="imperfecta" num="3" numbase="2"/>
+                                <note dur="longa" dur.quality="imperfecta"/>
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>
                                 <dot form="div"/>
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>
                                 <barLine form="dashed"/>
-                                <note dur="longa" dur.quality="imperfecta" num="3" numbase="2"/>
+                                <note dur="longa" dur.quality="imperfecta"/>
                                 <barLine form="dashed"/>
                             </layer>
                             <?edit-end?>

--- a/mei/dev/imperfection.mei
+++ b/mei/dev/imperfection.mei
@@ -21,15 +21,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="3"/>
                                 <note dur="longa" dur.quality="imperfecta"/>
                                 <barLine form="dashed"/>
                                 <note dur="brevis"/>
@@ -44,7 +43,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="3"/>
                                 <note dur="brevis" pname="a" oct="4"/>
                                 <note dur="brevis" pname="a" oct="4"/>
                                 <barLine form="dashed"/>

--- a/mei/dev/implicit-mensuration.mei
+++ b/mei/dev/implicit-mensuration.mei
@@ -24,19 +24,19 @@
         <body>
             <mdiv>
                 <score>
+                    <?edit-start?>
                     <scoreDef key.sig="1f">
                         <staffGrp>
-                            <staffDef n="1" label="Cantus" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="1"/>
-                            <staffDef n="2" label="Tenor" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="4"/>
-                            <staffDef n="3" label="Altus" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="3"/>
-                            <staffDef n="4" label="Bassus" lines="5" notationtype="mensural.white" clef.shape="F" clef.line="4"/>
+                            <staffDef n="1" label="Cantus" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="1" tempus="2" prolatio="2" mensur.sign="C" mensur.slash="1"/>
+                            <staffDef n="2" label="Tenor" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="4" tempus="2" prolatio="2" mensur.sign="C" mensur.slash="1"/>
+                            <staffDef n="3" label="Altus" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="3" tempus="2" prolatio="2"/>
+                            <staffDef n="4" label="Bassus" lines="5" notationtype="mensural.white" clef.shape="F" clef.line="4" tempus="2" prolatio="2"/>
                         </staffGrp>
                     </scoreDef>
-                    <?edit-start?>
+                    <?edit-end?>
                     <section>
                         <staff n="1">
                             <layer>
-                                <mensur sign="C" slash="1" tempus="2" prolatio="2"/>
                                 <note pname="b" oct="4" dur="brevis"/>
                                 <note pname="b" oct="4" dur="brevis"/>
                                 <note pname="a" oct="4" dur="brevis"/>
@@ -47,7 +47,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur sign="C" slash="1" tempus="2" prolatio="2"/>
                                 <note pname="g" oct="3" dur="brevis"/>
                                 <note pname="b" oct="3" dur="brevis"/>
                                 <note pname="c" oct="4" dur="brevis"/>
@@ -58,7 +57,6 @@
                         </staff>
                         <staff n="3">
                             <layer>
-                                <mensur tempus="2" prolatio="2"/>
                                 <note pname="d" oct="4" dur="brevis"/>
                                 <note pname="d" oct="4" dur="brevis"/>
                                 <note pname="f" oct="4" dur="brevis"/>
@@ -69,7 +67,6 @@
                         </staff>
                         <staff n="4">
                             <layer>
-                                <mensur tempus="2" prolatio="2"/>
                                 <note pname="g" oct="2" dur="brevis"/>
                                 <note pname="g" oct="3" dur="brevis"/>
                                 <note pname="g" oct="3" dur="brevis"/>
@@ -79,7 +76,6 @@
                             </layer>
                         </staff>
                     </section>
-                    <?edit-end?>
                 </score>
             </mdiv>
         </body>

--- a/mei/dev/mensuration_changes.mei
+++ b/mei/dev/mensuration_changes.mei
@@ -15,17 +15,16 @@
     <music>
         <body>
             <mdiv>
+                <?edit-start?>
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" notationtype="mensural" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" notationtype="mensural" lines="5" clef.shape="G" clef.line="2" mensur.sign="O" mensur.dot="true" mensur.slash="1" mensur.color="red"/>
                         </staffGrp>
                     </scoreDef>
-                    <?edit-start?>
                     <section>
                         <staff n="1">
                             <layer>
-                                <mensur sign="O" dot="true" slash="1" color="red"/>
                                 <note/>
                                 <note/>
                                 <note/>
@@ -36,8 +35,8 @@
                             </layer>
                         </staff>
                     </section>
-                    <?edit-end?>
                 </score>
+                <?edit-end?>
             </mdiv>
         </body>
     </music>

--- a/mei/dev/motet_fauvel_fol22r_triplum.mei
+++ b/mei/dev/motet_fauvel_fol22r_triplum.mei
@@ -21,13 +21,12 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" lines="5" label="Triplum" clef.shape="C" clef.line="3" notationtype="mensural.black"/>
+                            <staffDef n="1" lines="5" label="Triplum" clef.shape="C" clef.line="3" notationtype="mensural.black" modusminor="3" tempus="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <layer n="1">
-                                <mensur modusminor="3" tempus="3"/>
                                 <note dur="longa" oct="4" pname="c"/>
                                 <note dur="semibrevis" oct="4" pname="c"/>
                                 <note dur="semibrevis" oct="4" pname="d"/>

--- a/mei/dev/partial-imp-01-propinquam.mei
+++ b/mei/dev/partial-imp-01-propinquam.mei
@@ -21,15 +21,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="2" tempus="3"/>
                                 <note dur="longa" num="6" numbase="5"/>
                                 <barLine form="dotted"/>
                                 <note dur="semibrevis"/>
@@ -39,7 +38,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="2" tempus="3"/>
                                 <note dur="semibrevis" pname="a" oct="4"/>
                                 <note dur="semibrevis" pname="a" oct="4"/>
                                 <note dur="semibrevis" pname="a" oct="4"/>

--- a/mei/dev/partial-imp-02-bilateral.mei
+++ b/mei/dev/partial-imp-02-bilateral.mei
@@ -21,15 +21,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="2" tempus="3"/>
                                 <note dur="semibrevis"/>
                                 <barLine form="dotted"/>
                                 <note dur="longa" num="6" numbase="4"/>
@@ -41,7 +40,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="2" tempus="3"/>
                                 <note dur="semibrevis" pname="a" oct="4"/>
                                 <note dur="semibrevis" pname="a" oct="4"/>
                                 <note dur="semibrevis" pname="a" oct="4"/>

--- a/mei/dev/partial-imp-03-remotam.mei
+++ b/mei/dev/partial-imp-03-remotam.mei
@@ -21,15 +21,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" prolatio="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" prolatio="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="2" tempus="2" prolatio="3"/>
                                 <note dur="longa" num="12" numbase="11"/>
                                 <barLine form="dotted"/>
                                 <note dur="minima"/>
@@ -39,7 +38,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="2" tempus="2" prolatio="3"/>
                                 <note dur="minima" pname="a" oct="4"/>
                                 <note dur="minima" pname="a" oct="4"/>
                                 <note dur="minima" pname="a" oct="4"/>

--- a/mei/dev/partial-imp-04-remotam.mei
+++ b/mei/dev/partial-imp-04-remotam.mei
@@ -21,15 +21,14 @@
                 <score>
                     <scoreDef>
                         <staffGrp>
-                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
-                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2"/>
+                            <staffDef n="1" label="voice" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="2" prolatio="3"/>
+                            <staffDef n="2" label="reference" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="2" prolatio="3"/>
                         </staffGrp>
                     </scoreDef>
                     <section>
                         <staff n="1">
                             <?edit-start?>
                             <layer>
-                                <mensur modusminor="3" tempus="2" prolatio="3"/>
                                 <note dur="longa" num="18" numbase="17"/>
                                 <barLine form="dotted"/>
                                 <note dur="minima"/>
@@ -39,7 +38,6 @@
                         </staff>
                         <staff n="2">
                             <layer>
-                                <mensur modusminor="3" tempus="2" prolatio="3"/>
                                 <note dur="minima" pname="a" oct="4"/>
                                 <note dur="minima" pname="a" oct="4"/>
                                 <note dur="minima" pname="a" oct="4"/>


### PR DESCRIPTION
This PR updates the Mensural Notation chapter so that it is consistent with the changes in the schema. The main changes contained in this PR are:
- Removed the `@num` and `@numbase` attributes from the examples containing `@dur.quality`.
- Edit the sections **5.2 Mensurations** and **5.3 Proportions** to reflect the schema (which was changed by this revert commit https://github.com/music-encoding/music-encoding/commit/2a58dfbfd13c19dc2be0000349f70d3111f8b0ec). Changed the text of these two sections to something close to the text in version 4.0.1.
- Also changed all the examples encoding mensuration values (again, due to the previously mentioned revert commit). Mensuration was moved from `<mensur>` into `<staffDef>` once again.
