### PR TITLE
fix address of images

### DIFF
--- a/v4/content/neumes.html
+++ b/v4/content/neumes.html
@@ -153,8 +153,8 @@
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: center"><img src="/guidelines/images/v4/modules/neumes/NEUME-con.png" alt="Connected" /></td>
-      <td style="text-align: center"><img src="/guidelines/images/v4/modules/neumes/NEUME-non-con.png" alt="Non-connected" /></td>
+      <td style="text-align: center"><img src="/guidelines/v4/images/modules/neumes/NEUME-con.png" alt="Connected" /></td>
+      <td style="text-align: center"><img src="/guidelines/v4/images/modules/neumes/NEUME-non-con.png" alt="Non-connected" /></td>
     </tr>
   </tbody>
 </table>
@@ -193,9 +193,9 @@
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: center"><img src="/guidelines/images/v4/modules/neumes/NC-rhombusNEW.png" alt="nc-1" /></td>
-      <td style="text-align: center"><img src="/guidelines/images/v4/modules/neumes/NC-squareNEW.png" alt="nc-2" /></td>
-      <td style="text-align: center"><img src="/guidelines/images/v4/modules/neumes/NC-squaretailNEW.png" alt="nc-3" /></td>
+      <td style="text-align: center"><img src="/guidelines/v4/images/modules/neumes/NC-rhombusNEW.png" alt="nc-1" /></td>
+      <td style="text-align: center"><img src="/guidelines/v4/images/modules/neumes/NC-squareNEW.png" alt="nc-2" /></td>
+      <td style="text-align: center"><img src="/guidelines/v4/images/modules/neumes/NC-squaretailNEW.png" alt="nc-3" /></td>
     </tr>
   </tbody>
 </table>
@@ -314,7 +314,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>One pitch - Staff notation. Example A</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/one-pitch-ex-aNEW.png" alt="One pitch" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/one-pitch-ex-aNEW.png" alt="One pitch" /></td>
     </tr>
   </tbody>
 </table>
@@ -332,7 +332,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>One pitch - Staff notation. Example B</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/one-pitch-ex-bNEW.png" alt="One pitch" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/one-pitch-ex-bNEW.png" alt="One pitch" /></td>
     </tr>
   </tbody>
 </table>
@@ -350,7 +350,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>Two pitches - Staff notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/two-pitchesSN.png" alt="Two pitches" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/two-pitchesSN.png" alt="Two pitches" /></td>
     </tr>
   </tbody>
 </table>
@@ -369,7 +369,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>Four pitches - Staff notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/four-pitchesSN.png" alt="Four pitches" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/four-pitchesSN.png" alt="Four pitches" /></td>
     </tr>
   </tbody>
 </table>
@@ -452,7 +452,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>ORISCUS - Square notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/oriscus.png" alt="Oriscus1" title="Oriscus1" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/oriscus.png" alt="Oriscus1" title="Oriscus1" /></td>
     </tr>
   </tbody>
 </table>
@@ -472,7 +472,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>ORISCUS - St Gall notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/salicus.png" alt="Oriscus2" title="Oriscus2" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/salicus.png" alt="Oriscus2" title="Oriscus2" /></td>
     </tr>
   </tbody>
 </table>
@@ -514,7 +514,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>STROPHICUS - Square notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/strophicusNEW.png" alt="Strophicus" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/strophicusNEW.png" alt="Strophicus" width="200" /></td>
     </tr>
   </tbody>
 </table>
@@ -646,7 +646,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>GAPPED CONNECTION - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/gapped.png" alt="Gapped" title="Gapped" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/gapped.png" alt="Gapped" title="Gapped" /></td>
     </tr>
   </tbody>
 </table>
@@ -665,7 +665,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>LOOPED CONNECTION - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/looped.png" alt="Looped" title="Looped" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/looped.png" alt="Looped" title="Looped" /></td>
     </tr>
   </tbody>
 </table>
@@ -684,7 +684,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>EXTENDED CONNECTION - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/extended.png" alt="Extended" title="Extended" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/extended.png" alt="Extended" title="Extended" /></td>
     </tr>
   </tbody>
 </table>
@@ -705,7 +705,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>NON-EXTENDED CONNECTION - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/non-extended.png" alt="Non-extended" title="Non-extended connection" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/non-extended.png" alt="Non-extended" title="Non-extended connection" /></td>
     </tr>
   </tbody>
 </table>
@@ -752,7 +752,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>CURVE - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/curve.png" alt="Curve" title="Curve" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/curve.png" alt="Curve" title="Curve" /></td>
     </tr>
   </tbody>
 </table>
@@ -799,7 +799,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>ANGLED - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/angled.png" alt="Angled" title="Angled" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/angled.png" alt="Angled" title="Angled" /></td>
     </tr>
   </tbody>
 </table>
@@ -842,7 +842,7 @@ are used to describe sung gestures of 1, 2, and 4 notes in square notation.</p>
   <tbody>
     <tr>
       <td><strong>HOOK – Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/hooked.png" alt="Hook" title="Hook" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/hooked.png" alt="Hook" title="Hook" /></td>
     </tr>
   </tbody>
 </table>
@@ -910,7 +910,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>RELATIVE LENGTH – Old Hispanic notation. Example A</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/rellenA.png" alt="Relative-Length-A" title="Example A" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/rellenA.png" alt="Relative-Length-A" title="Example A" /></td>
     </tr>
   </tbody>
 </table>
@@ -929,7 +929,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>RELATIVE LENGTH – Old Hispanic notation. Example B</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/rellenL.png" alt="Relative-Length-B" title="Example B" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/rellenL.png" alt="Relative-Length-B" title="Example B" /></td>
     </tr>
   </tbody>
 </table>
@@ -982,7 +982,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>TILT – Old Hispanic / St Gall notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/tilt.png" alt="Tilt" title="Tilt" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/tilt.png" alt="Tilt" title="Tilt" /></td>
     </tr>
   </tbody>
 </table>
@@ -1032,7 +1032,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>S-SHAPE – Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/s-shapeA.png" alt="S-shape-A" title="Example A" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/s-shapeA.png" alt="S-shape-A" title="Example A" /></td>
     </tr>
   </tbody>
 </table>
@@ -1050,7 +1050,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>S-SHAPE – St Gall notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/s-shapeB.png" alt="S-shape-B" title="Example B" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/s-shapeB.png" alt="S-shape-B" title="Example B" /></td>
     </tr>
   </tbody>
 </table>
@@ -1129,7 +1129,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>CUSTOS - Staff notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/custos.EX1.png" alt="Custos1" title="Custos1" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/custos.EX1.png" alt="Custos1" title="Custos1" /></td>
     </tr>
   </tbody>
 </table>
@@ -1145,7 +1145,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>CUSTOS - Late Aquitanian notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/custos.EX2.png" alt="Custos2" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/custos.EX2.png" alt="Custos2" width="200" /></td>
     </tr>
   </tbody>
 </table>
@@ -1161,7 +1161,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>CUSTOS - Aquitanian notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/custos.EX3.png" alt="Custos3" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/custos.EX3.png" alt="Custos3" width="200" /></td>
     </tr>
   </tbody>
 </table>
@@ -1177,7 +1177,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>CUSTOS - Aquitanian notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/custos.EX4.png" alt="Custos4" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/custos.EX4.png" alt="Custos4" width="200" /></td>
     </tr>
   </tbody>
 </table>
@@ -1193,7 +1193,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>CUSTOS - Aquitanian notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/custos-and-lozenged-punctum.png" alt="Custos5" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/custos-and-lozenged-punctum.png" alt="Custos5" width="200" /></td>
     </tr>
   </tbody>
 </table>
@@ -1265,7 +1265,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>EPISEMA – Staff notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/episema.png" alt="Episema-A" title="Example A" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/episema.png" alt="Episema-A" title="Example A" /></td>
     </tr>
   </tbody>
 </table>
@@ -1286,7 +1286,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>EPISEMA - St Gall notation. Example A</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/episemaB.png" alt="Pes rotundus episema" title="Example B" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/episemaB.png" alt="Pes rotundus episema" title="Example B" /></td>
     </tr>
   </tbody>
 </table>
@@ -1307,7 +1307,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>EPISEMA - St Gall notation. Example B</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/episemaC.png" alt="Pes quadratus episema" title="Example C" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/episemaC.png" alt="Pes quadratus episema" title="Example C" /></td>
     </tr>
   </tbody>
 </table>
@@ -1328,7 +1328,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>EPISEMA - St Gall notation. Example C</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/episemaD.png" alt="Pes quassus episema" title="Example D" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/episemaD.png" alt="Pes quassus episema" title="Example D" /></td>
     </tr>
   </tbody>
 </table>
@@ -1407,7 +1407,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>LIQUESCENT - Staff notation. Example A</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/liquescent2NEW.png" alt="Liquescent.Ex.A." /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/liquescent2NEW.png" alt="Liquescent.Ex.A." /></td>
     </tr>
   </tbody>
 </table>
@@ -1427,7 +1427,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>LIQUESCENT - Staff notation. Example B</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/liquescent1NEW.png" alt="Liquescent.Ex.B" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/liquescent1NEW.png" alt="Liquescent.Ex.B" /></td>
     </tr>
   </tbody>
 </table>
@@ -1447,7 +1447,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>LIQUESCENT - Aquitanian notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/Aquitanian_liquescent.png" alt="Liquescent" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/Aquitanian_liquescent.png" alt="Liquescent" /></td>
     </tr>
   </tbody>
 </table>
@@ -1527,7 +1527,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>HISPAN TICK - Old Hispanic notation.</strong> The following encoding refers to the neume signalled by the arrow on the left.</td>
-      <td><img src="/guidelines/images/v4/modules/neumes/hispanTick.png" alt="Hispan tick" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/hispanTick.png" alt="Hispan tick" width="200" /></td>
     </tr>
   </tbody>
 </table>
@@ -1579,7 +1579,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>QUILISMA - Staff notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/quilisma.png" alt="Quilisma" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/quilisma.png" alt="Quilisma" /></td>
     </tr>
   </tbody>
 </table>
@@ -1602,7 +1602,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>QUILISMA - Old Hispanic notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/quilismaOH.png" alt="Quilisma2" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/quilismaOH.png" alt="Quilisma2" /></td>
     </tr>
   </tbody>
 </table>
@@ -1650,7 +1650,7 @@ See the encoding of the
   <tbody>
     <tr>
       <td><strong>SIGNIFICATIVE LETTERS - St Gall notation</strong></td>
-      <td><img src="/guidelines/images/v4/modules/neumes/signifLet.png" alt="Significative Letters" width="200" /></td>
+      <td><img src="/guidelines/v4/images/modules/neumes/signifLet.png" alt="Significative Letters" width="200" /></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
fix address of images in the [Neumes Notation Documentation v4](https://music-encoding.org/guidelines/v4/content/neumes.html) as in issue [#810](https://github.com/music-encoding/music-encoding/issues/810) in the [music-encoding repo](https://github.com/music-encoding/music-encoding).