### PR TITLE
Fix broken model links in v4

### DIFF
--- a/v4/content/cmn.html
+++ b/v4/content/cmn.html
@@ -2810,7 +2810,7 @@ A typical note, in this case a quarter note C4, is therefore encoded like so:</l
 
 <p>A common feature for keyboard music is fingering, indicating the finger, which should be used to play a single note. Basic fingering can be encoded in MEI using the 
   <a href="/guidelines/v4/elements/fing.html" class="link_odd_elementSpec">fing</a> element, which is a member of the 
-  <a href="/guidelines/v4/model-classes/model.model.fingeringlike.html">model.model.fingeringLike</a> class, and thus part of the 
+  <a href="/guidelines/v4/model-classes/model.fingeringlike.html">model.fingeringLike</a> class, and thus part of the 
   <a href="/guidelines/v4/model-classes/model.controleventlike.html">model.controlEventLike</a> class.</p>
 
 <p>The following example, taken from <a href="https://en.wikipedia.org/wiki/Charles-Louis_Hanon">Charles-Louis Hanon’s</a> <em>Le Pianiste virtuose</em>, shows typical fingering:</p>

--- a/v4/content/metadata.html
+++ b/v4/content/metadata.html
@@ -1266,7 +1266,7 @@ This concept is covered in section
 
 <p>It may contain either a single 
   <a href="/guidelines/v4/elements/unpub.html" class="link_odd_elementSpec">unpub</a> element, indicating that the file has yet to be published, or in the case of published material, one or more elements from the 
-  <a href="/guidelines/v4/model-classes/model.model.pubstmtpart.html">model.model.pubStmtPart</a> class. The following elements may be used to provide details regarding the file’s publication and distribution:</p>
+  <a href="/guidelines/v4/model-classes/model.pubstmtpart.html">model.pubStmtPart</a> class. The following elements may be used to provide details regarding the file’s publication and distribution:</p>
 
 <div class="tile tile-centered">
     <div class="tile-icon">

--- a/v4/content/shared.html
+++ b/v4/content/shared.html
@@ -671,7 +671,7 @@
 
 <p>Please note that 
   <a href="/guidelines/v4/elements/part.html" class="link_odd_elementSpec">part</a> elements in MEI are not an indication of voice leading or staff grouping. Voice leading can be encoded using the <strong>@next</strong> attribute, available on all the members of the 
-  <a href="/guidelines/v4/model-classes/model.model.eventlike.html">model.model.eventLike</a> class. The 
+  <a href="/guidelines/v4/model-classes/model.eventlike.html">model.eventLike</a> class. The 
   <a href="/guidelines/v4/elements/staffgrp.html" class="link_odd_elementSpec">staffGrp</a> element handles grouping of staves in the score context.</p>
 <div class="sampleCode" data-lang="">
 
@@ -2122,7 +2122,7 @@
     <div class="tile-content">
         <div class="tile-title">
               
-                <a href="/guidelines/v4/elements/model.graphicprimitivelike.html">model.graphicprimitiveLike</a>
+                <a href="/guidelines/v4/model-classes/model.graphicprimitivelike.html">model.graphicprimitiveLike</a>
             
         </div>
         <div class="tile-subtitle text-gray">
@@ -2141,7 +2141,7 @@
     <div class="tile-content">
         <div class="tile-title">
               
-                <a href="/guidelines/v4/elements/model.symboltablelike.html">model.symbolTableLike</a>
+                <a href="/guidelines/v4/model-classes/model.symboltablelike.html">model.symbolTableLike</a>
             
         </div>
         <div class="tile-subtitle text-gray">

--- a/v4/content/textencoding.html
+++ b/v4/content/textencoding.html
@@ -2165,7 +2165,7 @@
     <div class="tile-content">
         <div class="tile-title">
               
-                <a href="/guidelines/v4/elements/model.namelike.html">model.nameLike</a>
+                <a href="/guidelines/v4/model-classes/model.namelike.html">model.nameLike</a>
             
         </div>
         <div class="tile-subtitle text-gray">


### PR DESCRIPTION
This fixes some broken links in the Guidelines.
Closes https://github.com/music-encoding/music-encoding/issues/979